### PR TITLE
Don't round NYAN balance up on front page

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -74,7 +74,7 @@ class App extends Component {
     phone: 576,
   };
 
-  function toFixed(num, fixed) {
+  toFixed(num, fixed) {
     var re = new RegExp('^-?\\d+(?:\.\\d{0,' + (fixed || -1) + '})?');
     return num.toString().match(re)[0];
   }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -74,10 +74,13 @@ class App extends Component {
     phone: 576,
   };
 
-  
+  function toFixed(num, fixed) {
+    var re = new RegExp('^-?\\d+(?:\.\\d{0,' + (fixed || -1) + '})?');
+    return num.toString().match(re)[0];
+  }
 
   getRoundedNyanBalance() {
-    return parseFloat(this.state.nyanBalance).toFixed(6);
+    return toFixed(this.state.nyanBalance, 6);
   }
 
   getRoundedTotalNyanStaked() {


### PR DESCRIPTION
Better to round down than up because if you copy and paste the amount you could have a failed transaction because balance is just under.